### PR TITLE
Hide constructor functions and make thread-local

### DIFF
--- a/generator/generators/descriptorDecoder.mjs
+++ b/generator/generators/descriptorDecoder.mjs
@@ -70,7 +70,7 @@ ${padding}    }`;
     // validate class
     else if (type.isObject) {
       let unwrapType = getExplortDeclarationName(type.nativeType);
-      out += `\n${padding}    if (!(array.Get(ii).IsObject()) || !(array.Get(ii).As<Napi::Object>().InstanceOf(${unwrapType}::constructor.Value()))) {
+      out += `\n${padding}    if (!(array.Get(ii).IsObject()) || !(array.Get(ii).As<Napi::Object>().InstanceOf(${unwrapType}::GetConstructor().Value()))) {
 ${padding}      Napi::String type = Napi::String::New(value.Env(), "Type");
 ${padding}      Napi::String message = Napi::String::New(value.Env(), "Expected '${unwrapType}' for '${structure.externalName}'.'${member.name}'");
 ${padding}      device->throwCallbackError(type, message);
@@ -101,7 +101,7 @@ ${padding}}`;
     // class-based type check
     if (jsType.isObject && type.isObject) {
       let unwrapType = getExplortDeclarationName(type.nativeType);
-      out += `\n${padding}if (!(${input.name}.Get("${member.name}").IsObject()) || !(${input.name}.Get("${member.name}").As<Napi::Object>().InstanceOf(${unwrapType}::constructor.Value()))) {
+      out += `\n${padding}if (!(${input.name}.Get("${member.name}").IsObject()) || !(${input.name}.Get("${member.name}").As<Napi::Object>().InstanceOf(${unwrapType}::GetConstructor().Value()))) {
 ${padding}  Napi::String type = Napi::String::New(value.Env(), "Type");
 ${padding}  Napi::String message = Napi::String::New(value.Env(), "Expected '${unwrapType}' for '${structure.externalName}'.'${member.name}'");
 ${padding}  device->throwCallbackError(type, message);

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -53,7 +53,7 @@ function writeGeneratedFile(path, text, includeNotice = true) {
   }
 };
 
-async function generateBindings(version, enableMinification, includeMemoryLayouts) {
+function generateBindings(version, enableMinification, includeMemoryLayouts) {
   // copy dawn.json specification from dawn folder into into specification folder
   fs.copyFileSync(
     DAWN_PATH + "/dawn.json",

--- a/generator/index.mjs
+++ b/generator/index.mjs
@@ -34,10 +34,10 @@ const generatePath = `${generateVersionPath}/${getPlatform()}`;
 const generateSrcPath = `${generatePath}/src`;
 const bypassBuild = !!process.env.npm_config_bypass_build;
 
-// enables js interface minifcation
+// enables js interface minification
 const enableMinification = false;
 
-// indicating if it's necessary to include memorylayouts in the build
+// indicating if it's necessary to include memory layouts in the build
 const includeMemoryLayouts = false /*!fs.existsSync(`${generatePath}/memoryLayouts.json`)*/;
 
 function writeGeneratedFile(path, text, includeNotice = true) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1,8 +1,6 @@
 #include "GPU.h"
 #include "GPUAdapter.h"
 
-Napi::FunctionReference GPU::constructor;
-
 GPU::GPU(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPU>(info) { }
 GPU::~GPU() { }
 
@@ -25,7 +23,7 @@ Napi::Value GPU::requestAdapter(const Napi::CallbackInfo &info) {
 #endif
   ));
 
-  deferred.Resolve(GPUAdapter::constructor.New(args));
+  deferred.Resolve(GPUAdapter::GetConstructor().New(args));
 
   return deferred.Promise();
 }
@@ -39,7 +37,7 @@ Napi::Object GPU::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
-  constructor = Napi::Persistent(func);
+  thread_local Napi::FunctionReference constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPU", func);
   return exports;

--- a/src/GPU.h
+++ b/src/GPU.h
@@ -8,7 +8,6 @@ class GPU : public Napi::ObjectWrap<GPU> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
 
     static Napi::Value requestAdapter(const Napi::CallbackInfo &info);
 

--- a/src/GPUAdapter.cpp
+++ b/src/GPUAdapter.cpp
@@ -1,5 +1,4 @@
 #include "GPUAdapter.h"
-#include "WebGPUWindow.h"
 
 GPUAdapter::GPUAdapter(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUAdapter>(info) {
   Napi::Env env = info.Env();

--- a/src/GPUAdapter.cpp
+++ b/src/GPUAdapter.cpp
@@ -1,8 +1,6 @@
 #include "GPUAdapter.h"
 #include "WebGPUWindow.h"
 
-Napi::FunctionReference GPUAdapter::constructor;
-
 GPUAdapter::GPUAdapter(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUAdapter>(info) {
   Napi::Env env = info.Env();
 
@@ -52,7 +50,7 @@ Napi::Value GPUAdapter::requestDevice(const Napi::CallbackInfo &info) {
   };
   if (info[0].IsObject()) args.push_back(info[0].As<Napi::Value>());
 
-  Napi::Object device = GPUDevice::constructor.New(args);
+  Napi::Object device = GPUDevice::GetConstructor().New(args);
   deferred.Resolve(device);
 
   return deferred.Promise();
@@ -160,8 +158,15 @@ Napi::Object GPUAdapter::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUAdapter", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUAdapter::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUAdapter.h
+++ b/src/GPUAdapter.h
@@ -10,7 +10,7 @@ class GPUAdapter : public Napi::ObjectWrap<GPUAdapter> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUAdapter(const Napi::CallbackInfo &info);
     ~GPUAdapter();

--- a/src/GPUBindGroup.cpp
+++ b/src/GPUBindGroup.cpp
@@ -9,8 +9,6 @@
 
 #include <vector>
 
-Napi::FunctionReference GPUBindGroup::constructor;
-
 GPUBindGroup::GPUBindGroup(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUBindGroup>(info) {
   Napi::Env env = info.Env();
 
@@ -32,8 +30,14 @@ Napi::Object GPUBindGroup::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPUBindGroup", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUBindGroup", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUBindGroup::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUBindGroup.h
+++ b/src/GPUBindGroup.h
@@ -8,7 +8,7 @@ class GPUBindGroup : public Napi::ObjectWrap<GPUBindGroup> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUBindGroup(const Napi::CallbackInfo &info);
     ~GPUBindGroup();

--- a/src/GPUBindGroupLayout.cpp
+++ b/src/GPUBindGroupLayout.cpp
@@ -3,8 +3,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUBindGroupLayout::constructor;
-
 GPUBindGroupLayout::GPUBindGroupLayout(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUBindGroupLayout>(info) {
   Napi::Env env = info.Env();
 
@@ -26,8 +24,14 @@ Napi::Object GPUBindGroupLayout::Initialize(Napi::Env env, Napi::Object exports)
   Napi::Function func = DefineClass(env, "GPUBindGroupLayout", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUBindGroupLayout", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUBindGroupLayout::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUBindGroupLayout.h
+++ b/src/GPUBindGroupLayout.h
@@ -8,7 +8,7 @@ class GPUBindGroupLayout : public Napi::ObjectWrap<GPUBindGroupLayout> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUBindGroupLayout(const Napi::CallbackInfo &info);
     ~GPUBindGroupLayout();

--- a/src/GPUBuffer.cpp
+++ b/src/GPUBuffer.cpp
@@ -7,8 +7,6 @@
 #include <chrono>
 #include <cstdint>
 
-Napi::FunctionReference GPUBuffer::constructor;
-
 struct BufferCallbackResult {
   void* addr = nullptr;
   uint64_t length = 0;
@@ -192,8 +190,14 @@ Napi::Object GPUBuffer::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUBuffer", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUBuffer::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUBuffer.h
+++ b/src/GPUBuffer.h
@@ -8,7 +8,7 @@ class GPUBuffer : public Napi::ObjectWrap<GPUBuffer> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUBuffer(const Napi::CallbackInfo &info);
     ~GPUBuffer();

--- a/src/GPUCanvasContext.cpp
+++ b/src/GPUCanvasContext.cpp
@@ -7,8 +7,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUCanvasContext::constructor;
-
 GPUCanvasContext::GPUCanvasContext(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUCanvasContext>(info) {
   this->window.Reset(info[0].As<Napi::Object>(), 1);
 }
@@ -19,7 +17,7 @@ GPUCanvasContext::~GPUCanvasContext() {
 
 Napi::Value GPUCanvasContext::configureSwapChain(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object swapchain = GPUSwapChain::constructor.New({
+  Napi::Object swapchain = GPUSwapChain::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -67,8 +65,14 @@ Napi::Object GPUCanvasContext::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUCanvasContext", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUCanvasContext::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUCanvasContext.h
+++ b/src/GPUCanvasContext.h
@@ -8,7 +8,7 @@ class GPUCanvasContext : public Napi::ObjectWrap<GPUCanvasContext> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUCanvasContext(const Napi::CallbackInfo &info);
     ~GPUCanvasContext();

--- a/src/GPUCommandBuffer.cpp
+++ b/src/GPUCommandBuffer.cpp
@@ -1,7 +1,5 @@
 #include "GPUCommandBuffer.h"
 
-Napi::FunctionReference GPUCommandBuffer::constructor;
-
 GPUCommandBuffer::GPUCommandBuffer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUCommandBuffer>(info) {
 
 }
@@ -15,8 +13,14 @@ Napi::Object GPUCommandBuffer::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPUCommandBuffer", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUCommandBuffer", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUCommandBuffer::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUCommandBuffer.h
+++ b/src/GPUCommandBuffer.h
@@ -8,7 +8,7 @@ class GPUCommandBuffer : public Napi::ObjectWrap<GPUCommandBuffer> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUCommandBuffer(const Napi::CallbackInfo &info);
     ~GPUCommandBuffer();

--- a/src/GPUCommandEncoder.cpp
+++ b/src/GPUCommandEncoder.cpp
@@ -11,8 +11,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUCommandEncoder::constructor;
-
 GPUCommandEncoder::GPUCommandEncoder(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUCommandEncoder>(info) {
   Napi::Env env = info.Env();
 
@@ -31,7 +29,7 @@ GPUCommandEncoder::~GPUCommandEncoder() {
 
 Napi::Value GPUCommandEncoder::beginRenderPass(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object renderPass = GPURenderPassEncoder::constructor.New({
+  Napi::Object renderPass = GPURenderPassEncoder::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -40,7 +38,7 @@ Napi::Value GPUCommandEncoder::beginRenderPass(const Napi::CallbackInfo &info) {
 
 Napi::Value GPUCommandEncoder::beginComputePass(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object computePass = GPUComputePassEncoder::constructor.New({
+  Napi::Object computePass = GPUComputePassEncoder::GetConstructor().New({
     info.This().As<Napi::Value>(),
     Napi::Object::New(env).As<Napi::Value>()
   });
@@ -51,7 +49,7 @@ Napi::Value GPUCommandEncoder::beginComputePass(const Napi::CallbackInfo &info) 
 #if 0
 Napi::Value GPUCommandEncoder::beginRayTracingPass(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object rayTracingPass = GPURayTracingPassEncoder::constructor.New({
+  Napi::Object rayTracingPass = GPURayTracingPassEncoder::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -203,7 +201,7 @@ Napi::Value GPUCommandEncoder::finish(const Napi::CallbackInfo &info) {
 
   WGPUCommandBuffer buffer = wgpuCommandEncoderFinish(this->instance, nullptr);
 
-  Napi::Object commandBuffer = GPUCommandBuffer::constructor.New({});
+  Napi::Object commandBuffer = GPUCommandBuffer::GetConstructor().New({});
   GPUCommandBuffer* uwCommandBuffer = Napi::ObjectWrap<GPUCommandBuffer>::Unwrap(commandBuffer);
   uwCommandBuffer->instance = buffer;
 
@@ -291,8 +289,14 @@ Napi::Object GPUCommandEncoder::Initialize(Napi::Env env, Napi::Object exports) 
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUCommandEncoder", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUCommandEncoder::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUCommandEncoder.h
+++ b/src/GPUCommandEncoder.h
@@ -8,7 +8,7 @@ class GPUCommandEncoder : public Napi::ObjectWrap<GPUCommandEncoder> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUCommandEncoder(const Napi::CallbackInfo &info);
     ~GPUCommandEncoder();

--- a/src/GPUComputePassEncoder.cpp
+++ b/src/GPUComputePassEncoder.cpp
@@ -7,8 +7,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUComputePassEncoder::constructor;
-
 GPUComputePassEncoder::GPUComputePassEncoder(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUComputePassEncoder>(info) {
   Napi::Env env = info.Env();
 
@@ -159,8 +157,14 @@ Napi::Object GPUComputePassEncoder::Initialize(Napi::Env env, Napi::Object expor
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUComputePassEncoder", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUComputePassEncoder::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUComputePassEncoder.h
+++ b/src/GPUComputePassEncoder.h
@@ -8,7 +8,7 @@ class GPUComputePassEncoder : public Napi::ObjectWrap<GPUComputePassEncoder> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUComputePassEncoder(const Napi::CallbackInfo &info);
     ~GPUComputePassEncoder();

--- a/src/GPUComputePipeline.cpp
+++ b/src/GPUComputePipeline.cpp
@@ -4,8 +4,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUComputePipeline::constructor;
-
 GPUComputePipeline::GPUComputePipeline(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUComputePipeline>(info) {
   Napi::Env env = info.Env();
 
@@ -27,8 +25,14 @@ Napi::Object GPUComputePipeline::Initialize(Napi::Env env, Napi::Object exports)
   Napi::Function func = DefineClass(env, "GPUComputePipeline", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUComputePipeline", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUComputePipeline::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUComputePipeline.h
+++ b/src/GPUComputePipeline.h
@@ -8,7 +8,7 @@ class GPUComputePipeline : public Napi::ObjectWrap<GPUComputePipeline> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUComputePipeline(const Napi::CallbackInfo &info);
     ~GPUComputePipeline();

--- a/src/GPUDevice.cpp
+++ b/src/GPUDevice.cpp
@@ -22,8 +22,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUDevice::constructor;
-
 GPUDevice::GPUDevice(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUDevice>(info) {
   Napi::Env env = info.Env();
 
@@ -125,7 +123,7 @@ BackendBinding* GPUDevice::createBinding(const Napi::CallbackInfo& info, WGPUDev
 
 Napi::Object GPUDevice::createQueue(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::Object queue = GPUQueue::constructor.New({
+  Napi::Object queue = GPUQueue::GetConstructor().New({
     info.This().As<Napi::Value>()
   });
   return queue;
@@ -169,7 +167,7 @@ Napi::Value GPUDevice::tick(const Napi::CallbackInfo& info) {
 #if 0
 Napi::Value GPUDevice::createRayTracingAccelerationContainer(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::Object accelerationContainer = GPURayTracingAccelerationContainer::constructor.New({
+  Napi::Object accelerationContainer = GPURayTracingAccelerationContainer::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -178,7 +176,7 @@ Napi::Value GPUDevice::createRayTracingAccelerationContainer(const Napi::Callbac
 
 Napi::Value GPUDevice::createRayTracingShaderBindingTable(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::Object shaderBindingTable = GPURayTracingShaderBindingTable::constructor.New({
+  Napi::Object shaderBindingTable = GPURayTracingShaderBindingTable::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -187,7 +185,7 @@ Napi::Value GPUDevice::createRayTracingShaderBindingTable(const Napi::CallbackIn
 
 Napi::Value GPUDevice::createRayTracingPipeline(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::Object rayTracingPipeline = GPURayTracingPipeline::constructor.New({
+  Napi::Object rayTracingPipeline = GPURayTracingPipeline::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -197,7 +195,7 @@ Napi::Value GPUDevice::createRayTracingPipeline(const Napi::CallbackInfo& info) 
 
 Napi::Value GPUDevice::createBuffer(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::Object buffer = GPUBuffer::constructor.New({
+  Napi::Object buffer = GPUBuffer::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -206,7 +204,7 @@ Napi::Value GPUDevice::createBuffer(const Napi::CallbackInfo& info) {
 
 Napi::Value GPUDevice::createBufferMapped(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object buffer = GPUBuffer::constructor.New({
+  Napi::Object buffer = GPUBuffer::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -220,7 +218,7 @@ Napi::Value GPUDevice::createBufferMapped(const Napi::CallbackInfo &info) {
 
 Napi::Value GPUDevice::createBufferMappedAsync(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object buffer = GPUBuffer::constructor.New({
+  Napi::Object buffer = GPUBuffer::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -236,7 +234,7 @@ Napi::Value GPUDevice::createBufferMappedAsync(const Napi::CallbackInfo &info) {
 
 Napi::Value GPUDevice::createTexture(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object texture = GPUTexture::constructor.New({
+  Napi::Object texture = GPUTexture::GetConstructor().New({
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   });
@@ -249,7 +247,7 @@ Napi::Value GPUDevice::createSampler(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>()
   };
   if (info[0].IsObject()) args.push_back(info[0].As<Napi::Value>());
-  Napi::Object sampler = GPUSampler::constructor.New(args);
+  Napi::Object sampler = GPUSampler::GetConstructor().New(args);
   return sampler;
 }
 
@@ -259,7 +257,7 @@ Napi::Value GPUDevice::createBindGroupLayout(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object bindGroupLayout = GPUBindGroupLayout::constructor.New(args);
+  Napi::Object bindGroupLayout = GPUBindGroupLayout::GetConstructor().New(args);
   return bindGroupLayout;
 }
 
@@ -269,7 +267,7 @@ Napi::Value GPUDevice::createPipelineLayout(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object pipelineLayout = GPUPipelineLayout::constructor.New(args);
+  Napi::Object pipelineLayout = GPUPipelineLayout::GetConstructor().New(args);
   return pipelineLayout;
 }
 
@@ -279,7 +277,7 @@ Napi::Value GPUDevice::createBindGroup(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object bindGroup = GPUBindGroup::constructor.New(args);
+  Napi::Object bindGroup = GPUBindGroup::GetConstructor().New(args);
   return bindGroup;
 }
 
@@ -289,7 +287,7 @@ Napi::Value GPUDevice::createShaderModule(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object shaderModule = GPUShaderModule::constructor.New(args);
+  Napi::Object shaderModule = GPUShaderModule::GetConstructor().New(args);
   return shaderModule;
 }
 
@@ -299,7 +297,7 @@ Napi::Value GPUDevice::createComputePipeline(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object computePipeline = GPUComputePipeline::constructor.New(args);
+  Napi::Object computePipeline = GPUComputePipeline::GetConstructor().New(args);
   return computePipeline;
 }
 
@@ -309,7 +307,7 @@ Napi::Value GPUDevice::createRenderPipeline(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object renderPipeline = GPURenderPipeline::constructor.New(args);
+  Napi::Object renderPipeline = GPURenderPipeline::GetConstructor().New(args);
   return renderPipeline;
 }
 
@@ -319,7 +317,7 @@ Napi::Value GPUDevice::createCommandEncoder(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>()
   };
   args.push_back(Napi::Object::New(env).As<Napi::Value>());
-  Napi::Object commandEncoder = GPUCommandEncoder::constructor.New(args);
+  Napi::Object commandEncoder = GPUCommandEncoder::GetConstructor().New(args);
   return commandEncoder;
 }
 
@@ -329,7 +327,7 @@ Napi::Value GPUDevice::createRenderBundleEncoder(const Napi::CallbackInfo &info)
     info.This().As<Napi::Value>(),
     info[0].As<Napi::Value>()
   };
-  Napi::Object renderBundleEncoder = GPURenderBundleEncoder::constructor.New(args);
+  Napi::Object renderBundleEncoder = GPURenderBundleEncoder::GetConstructor().New(args);
   return renderBundleEncoder;
 }
 
@@ -458,8 +456,14 @@ Napi::Object GPUDevice::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUDevice", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUDevice::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUDevice.h
+++ b/src/GPUDevice.h
@@ -10,7 +10,7 @@ class GPUDevice : public Napi::ObjectWrap<GPUDevice> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUDevice(const Napi::CallbackInfo &info);
     ~GPUDevice();

--- a/src/GPUFence.cpp
+++ b/src/GPUFence.cpp
@@ -7,8 +7,6 @@
 #include <thread>
 #include <chrono>
 
-Napi::FunctionReference GPUFence::constructor;
-
 GPUFence::GPUFence(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUFence>(info) {
   Napi::Env env = info.Env();
 
@@ -80,8 +78,14 @@ Napi::Object GPUFence::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUFence", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUFence::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUFence.h
+++ b/src/GPUFence.h
@@ -8,7 +8,7 @@ class GPUFence : public Napi::ObjectWrap<GPUFence> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUFence(const Napi::CallbackInfo &info);
     ~GPUFence();

--- a/src/GPUPipelineLayout.cpp
+++ b/src/GPUPipelineLayout.cpp
@@ -6,8 +6,6 @@
 
 #include <vector>
 
-Napi::FunctionReference GPUPipelineLayout::constructor;
-
 GPUPipelineLayout::GPUPipelineLayout(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUPipelineLayout>(info) {
   Napi::Env env = info.Env();
 
@@ -29,8 +27,14 @@ Napi::Object GPUPipelineLayout::Initialize(Napi::Env env, Napi::Object exports) 
   Napi::Function func = DefineClass(env, "GPUPipelineLayout", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUPipelineLayout", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUPipelineLayout::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUPipelineLayout.h
+++ b/src/GPUPipelineLayout.h
@@ -8,7 +8,7 @@ class GPUPipelineLayout : public Napi::ObjectWrap<GPUPipelineLayout> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUPipelineLayout(const Napi::CallbackInfo &info);
     ~GPUPipelineLayout();

--- a/src/GPUQueue.cpp
+++ b/src/GPUQueue.cpp
@@ -5,8 +5,6 @@
 
 #include <vector>
 
-Napi::FunctionReference GPUQueue::constructor;
-
 GPUQueue::GPUQueue(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUQueue>(info) {
   Napi::Env env = info.Env();
 
@@ -47,7 +45,7 @@ Napi::Value GPUQueue::createFence(const Napi::CallbackInfo &info) {
   if (info[0].IsObject()) {
     args.push_back(info[0].As<Napi::Value>());
   }
-  Napi::Object fence = GPUFence::constructor.New(args);
+  Napi::Object fence = GPUFence::GetConstructor().New(args);
   return fence;
 }
 
@@ -81,8 +79,14 @@ Napi::Object GPUQueue::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUQueue", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUQueue::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUQueue.h
+++ b/src/GPUQueue.h
@@ -8,7 +8,7 @@ class GPUQueue : public Napi::ObjectWrap<GPUQueue> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUQueue(const Napi::CallbackInfo &info);
     ~GPUQueue();

--- a/src/GPURayTracingAccelerationContainer.cpp
+++ b/src/GPURayTracingAccelerationContainer.cpp
@@ -9,8 +9,6 @@
 #include <chrono>
 #include <cstdint>
 
-Napi::FunctionReference GPURayTracingAccelerationContainer::constructor;
-
 GPURayTracingAccelerationContainer::GPURayTracingAccelerationContainer(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURayTracingAccelerationContainer>(info) {
   Napi::Env env = info.Env();
 
@@ -57,10 +55,16 @@ Napi::Object GPURayTracingAccelerationContainer::Initialize(Napi::Env env, Napi:
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURayTracingAccelerationContainer", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURayTracingAccelerationContainer::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }
 
 #endif

--- a/src/GPURayTracingAccelerationContainer.h
+++ b/src/GPURayTracingAccelerationContainer.h
@@ -10,7 +10,7 @@ class GPURayTracingAccelerationContainer : public Napi::ObjectWrap<GPURayTracing
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURayTracingAccelerationContainer(const Napi::CallbackInfo &info);
     ~GPURayTracingAccelerationContainer();

--- a/src/GPURayTracingPassEncoder.cpp
+++ b/src/GPURayTracingPassEncoder.cpp
@@ -8,8 +8,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPURayTracingPassEncoder::constructor;
-
 GPURayTracingPassEncoder::GPURayTracingPassEncoder(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURayTracingPassEncoder>(info) {
   Napi::Env env = info.Env();
 
@@ -158,10 +156,16 @@ Napi::Object GPURayTracingPassEncoder::Initialize(Napi::Env env, Napi::Object ex
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURayTracingPassEncoder", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURayTracingPassEncoder::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }
 
 #endif

--- a/src/GPURayTracingPassEncoder.h
+++ b/src/GPURayTracingPassEncoder.h
@@ -10,7 +10,7 @@ class GPURayTracingPassEncoder : public Napi::ObjectWrap<GPURayTracingPassEncode
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURayTracingPassEncoder(const Napi::CallbackInfo &info);
     ~GPURayTracingPassEncoder();

--- a/src/GPURayTracingPipeline.cpp
+++ b/src/GPURayTracingPipeline.cpp
@@ -6,8 +6,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPURayTracingPipeline::constructor;
-
 GPURayTracingPipeline::GPURayTracingPipeline(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURayTracingPipeline>(info) {
   Napi::Env env = info.Env();
 
@@ -29,10 +27,16 @@ Napi::Object GPURayTracingPipeline::Initialize(Napi::Env env, Napi::Object expor
   Napi::Function func = DefineClass(env, "GPURayTracingPipeline", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURayTracingPipeline", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURayTracingPipeline::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }
 
 #endif

--- a/src/GPURayTracingPipeline.h
+++ b/src/GPURayTracingPipeline.h
@@ -10,7 +10,7 @@ class GPURayTracingPipeline : public Napi::ObjectWrap<GPURayTracingPipeline> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURayTracingPipeline(const Napi::CallbackInfo &info);
     ~GPURayTracingPipeline();

--- a/src/GPURayTracingShaderBindingTable.cpp
+++ b/src/GPURayTracingShaderBindingTable.cpp
@@ -9,8 +9,6 @@
 #include <chrono>
 #include <cstdint>
 
-Napi::FunctionReference GPURayTracingShaderBindingTable::constructor;
-
 GPURayTracingShaderBindingTable::GPURayTracingShaderBindingTable(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURayTracingShaderBindingTable>(info) {
   Napi::Env env = info.Env();
 
@@ -41,10 +39,16 @@ Napi::Object GPURayTracingShaderBindingTable::Initialize(Napi::Env env, Napi::Ob
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURayTracingShaderBindingTable", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURayTracingShaderBindingTable::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }
 
 #endif

--- a/src/GPURayTracingShaderBindingTable.h
+++ b/src/GPURayTracingShaderBindingTable.h
@@ -10,7 +10,7 @@ class GPURayTracingShaderBindingTable : public Napi::ObjectWrap<GPURayTracingSha
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURayTracingShaderBindingTable(const Napi::CallbackInfo &info);
     ~GPURayTracingShaderBindingTable();

--- a/src/GPURenderBundle.cpp
+++ b/src/GPURenderBundle.cpp
@@ -1,7 +1,5 @@
 #include "GPURenderBundle.h"
 
-Napi::FunctionReference GPURenderBundle::constructor;
-
 GPURenderBundle::GPURenderBundle(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURenderBundle>(info) {
 
 }
@@ -15,8 +13,14 @@ Napi::Object GPURenderBundle::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPURenderBundle", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURenderBundle", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURenderBundle::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPURenderBundle.h
+++ b/src/GPURenderBundle.h
@@ -8,7 +8,7 @@ class GPURenderBundle : public Napi::ObjectWrap<GPURenderBundle> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURenderBundle(const Napi::CallbackInfo &info);
     ~GPURenderBundle();

--- a/src/GPURenderBundleEncoder.cpp
+++ b/src/GPURenderBundleEncoder.cpp
@@ -7,8 +7,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPURenderBundleEncoder::constructor;
-
 GPURenderBundleEncoder::GPURenderBundleEncoder(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURenderBundleEncoder>(info) {
   Napi::Env env = info.Env();
 
@@ -247,8 +245,14 @@ Napi::Object GPURenderBundleEncoder::Initialize(Napi::Env env, Napi::Object expo
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURenderBundleEncoder", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURenderBundleEncoder::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPURenderBundleEncoder.h
+++ b/src/GPURenderBundleEncoder.h
@@ -8,7 +8,7 @@ class GPURenderBundleEncoder : public Napi::ObjectWrap<GPURenderBundleEncoder> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURenderBundleEncoder(const Napi::CallbackInfo &info);
     ~GPURenderBundleEncoder();

--- a/src/GPURenderPassEncoder.cpp
+++ b/src/GPURenderPassEncoder.cpp
@@ -7,8 +7,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPURenderPassEncoder::constructor;
-
 GPURenderPassEncoder::GPURenderPassEncoder(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURenderPassEncoder>(info) {
   Napi::Env env = info.Env();
 
@@ -324,8 +322,14 @@ Napi::Object GPURenderPassEncoder::Initialize(Napi::Env env, Napi::Object export
       napi_enumerable
     ),
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURenderPassEncoder", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURenderPassEncoder::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPURenderPassEncoder.h
+++ b/src/GPURenderPassEncoder.h
@@ -12,7 +12,7 @@ class GPURenderPassEncoder : public Napi::ObjectWrap<GPURenderPassEncoder> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURenderPassEncoder(const Napi::CallbackInfo &info);
     ~GPURenderPassEncoder();

--- a/src/GPURenderPipeline.cpp
+++ b/src/GPURenderPipeline.cpp
@@ -4,8 +4,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPURenderPipeline::constructor;
-
 GPURenderPipeline::GPURenderPipeline(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPURenderPipeline>(info) {
   Napi::Env env = info.Env();
 
@@ -27,8 +25,14 @@ Napi::Object GPURenderPipeline::Initialize(Napi::Env env, Napi::Object exports) 
   Napi::Function func = DefineClass(env, "GPURenderPipeline", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPURenderPipeline", func);
   return exports;
+}
+
+Napi::FunctionReference &GPURenderPipeline::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPURenderPipeline.h
+++ b/src/GPURenderPipeline.h
@@ -8,7 +8,7 @@ class GPURenderPipeline : public Napi::ObjectWrap<GPURenderPipeline> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPURenderPipeline(const Napi::CallbackInfo &info);
     ~GPURenderPipeline();

--- a/src/GPUSampler.cpp
+++ b/src/GPUSampler.cpp
@@ -3,8 +3,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUSampler::constructor;
-
 GPUSampler::GPUSampler(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUSampler>(info) {
   Napi::Env env = info.Env();
 
@@ -26,8 +24,14 @@ Napi::Object GPUSampler::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPUSampler", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUSampler", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUSampler::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUSampler.h
+++ b/src/GPUSampler.h
@@ -8,7 +8,7 @@ class GPUSampler : public Napi::ObjectWrap<GPUSampler> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUSampler(const Napi::CallbackInfo &info);
     ~GPUSampler();

--- a/src/GPUShaderModule.cpp
+++ b/src/GPUShaderModule.cpp
@@ -5,8 +5,6 @@
 
 #include <shaderc/shaderc.hpp>
 
-Napi::FunctionReference GPUShaderModule::constructor;
-
 GPUShaderModule::GPUShaderModule(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUShaderModule>(info) {
   Napi::Env env = info.Env();
 
@@ -91,8 +89,14 @@ Napi::Object GPUShaderModule::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPUShaderModule", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUShaderModule", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUShaderModule::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUShaderModule.h
+++ b/src/GPUShaderModule.h
@@ -8,7 +8,7 @@ class GPUShaderModule : public Napi::ObjectWrap<GPUShaderModule> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUShaderModule(const Napi::CallbackInfo &info);
     ~GPUShaderModule();

--- a/src/GPUSwapChain.cpp
+++ b/src/GPUSwapChain.cpp
@@ -7,8 +7,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUSwapChain::constructor;
-
 GPUSwapChain::GPUSwapChain(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUSwapChain>(info) {
   Napi::Env env = info.Env();
 
@@ -62,7 +60,7 @@ Napi::Value GPUSwapChain::getCurrentTextureView(const Napi::CallbackInfo &info) 
     info[0].As<Napi::Value>(),
     Napi::Boolean::New(env, true)
   };
-  Napi::Object textureView = GPUTextureView::constructor.New(args);
+  Napi::Object textureView = GPUTextureView::GetConstructor().New(args);
 
   GPUTextureView* uwTexture = Napi::ObjectWrap<GPUTextureView>::Unwrap(textureView);
   uwTexture->instance = nextTextureView;
@@ -92,8 +90,14 @@ Napi::Object GPUSwapChain::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUSwapChain", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUSwapChain::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUSwapChain.h
+++ b/src/GPUSwapChain.h
@@ -8,7 +8,7 @@ class GPUSwapChain : public Napi::ObjectWrap<GPUSwapChain> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUSwapChain(const Napi::CallbackInfo &info);
     ~GPUSwapChain();

--- a/src/GPUTexture.cpp
+++ b/src/GPUTexture.cpp
@@ -4,8 +4,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUTexture::constructor;
-
 GPUTexture::GPUTexture(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUTexture>(info) {
   Napi::Env env = info.Env();
 
@@ -38,7 +36,7 @@ Napi::Value GPUTexture::createView(const Napi::CallbackInfo &info) {
     info.This().As<Napi::Value>()
   };
   if (info[0].IsObject()) args.push_back(info[0].As<Napi::Value>());
-  Napi::Object textureView = GPUTextureView::constructor.New(args);
+  Napi::Object textureView = GPUTextureView::GetConstructor().New(args);
   return textureView;
 }
 
@@ -62,8 +60,14 @@ Napi::Object GPUTexture::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUTexture", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUTexture::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUTexture.h
+++ b/src/GPUTexture.h
@@ -8,7 +8,7 @@ class GPUTexture : public Napi::ObjectWrap<GPUTexture> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUTexture(const Napi::CallbackInfo &info);
     ~GPUTexture();

--- a/src/GPUTextureView.cpp
+++ b/src/GPUTextureView.cpp
@@ -3,8 +3,6 @@
 
 #include "DescriptorDecoder.h"
 
-Napi::FunctionReference GPUTextureView::constructor;
-
 GPUTextureView::GPUTextureView(const Napi::CallbackInfo& info) : Napi::ObjectWrap<GPUTextureView>(info) {
   Napi::Env env = info.Env();
 
@@ -34,8 +32,14 @@ Napi::Object GPUTextureView::Initialize(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "GPUTextureView", {
 
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("GPUTextureView", func);
   return exports;
+}
+
+Napi::FunctionReference &GPUTextureView::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/GPUTextureView.h
+++ b/src/GPUTextureView.h
@@ -8,7 +8,7 @@ class GPUTextureView : public Napi::ObjectWrap<GPUTextureView> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     GPUTextureView(const Napi::CallbackInfo &info);
     ~GPUTextureView();

--- a/src/WebGPUWindow.cpp
+++ b/src/WebGPUWindow.cpp
@@ -1,8 +1,6 @@
 #include "WebGPUWindow.h"
 #include "GPUCanvasContext.h"
 
-Napi::FunctionReference WebGPUWindow::constructor;
-
 WebGPUWindow::WebGPUWindow(const Napi::CallbackInfo& info) : Napi::ObjectWrap<WebGPUWindow>(info), env_(info.Env()) {
   Napi::Env env = env_;
   if (info.IsConstructCall()) {
@@ -231,7 +229,7 @@ Napi::Value WebGPUWindow::close(const Napi::CallbackInfo& info) {
 
 Napi::Value WebGPUWindow::getContext(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  Napi::Object canvasContext = GPUCanvasContext::constructor.New({
+  Napi::Object canvasContext = GPUCanvasContext::GetConstructor().New({
     info.This().As<Napi::Value>()
   });
   return canvasContext;
@@ -582,8 +580,14 @@ Napi::Object WebGPUWindow::Initialize(Napi::Env env, Napi::Object exports) {
       napi_enumerable
     )
   });
+  auto &constructor = GetConstructor();
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("WebGPUWindow", func);
   return exports;
+}
+
+Napi::FunctionReference &WebGPUWindow::GetConstructor() {
+  thread_local Napi::FunctionReference constructor;
+  return constructor;
 }

--- a/src/WebGPUWindow.h
+++ b/src/WebGPUWindow.h
@@ -9,7 +9,7 @@ class WebGPUWindow : public Napi::ObjectWrap<WebGPUWindow> {
   public:
 
     static Napi::Object Initialize(Napi::Env env, Napi::Object exports);
-    static Napi::FunctionReference constructor;
+    static Napi::FunctionReference &GetConstructor();
 
     WebGPUWindow(const Napi::CallbackInfo &info);
     ~WebGPUWindow();


### PR DESCRIPTION
This fixes usage in a multi-threaded context. Formerly, there was one static constructor function for each type, each containing its own Env instance. When Init() was called on another thread for a separate thread-local isolate, the static constructor function would be replaced. This came to my attention because it tripped an assertion due to the Env instance created on one thread being destroyed on another thread. Now, each thread has its own copy of the constructor function.